### PR TITLE
Two minor improvements - findByTag and hidden type support like android

### DIFF
--- a/CSLinearLayoutView/CSLinearLayoutView.h
+++ b/CSLinearLayoutView/CSLinearLayoutView.h
@@ -86,12 +86,18 @@ typedef struct {
     CGFloat right;
 } CSLinearLayoutItemPadding;
 
+NS_ENUM(NSInteger, CSLinearLayoutItemVisibility) {
+    CSLinearLayoutItemHidden,             // Occupy the frame
+    CSLinearLayoutItemGone                // Missing in the layout
+};
+
 @interface CSLinearLayoutItem : NSObject
 
 @property (nonatomic, strong) UIView *view;
 @property (nonatomic, assign) CSLinearLayoutItemFillMode fillMode;
 @property (nonatomic, assign) CSLinearLayoutItemHorizontalAlignment horizontalAlignment;    // Use horizontalAlignment when the layout view is set to VERTICAL orientation
 @property (nonatomic, assign) CSLinearLayoutItemVerticalAlignment verticalAlignment;        // Use verticalAlignment when the layout view is set to HORIZONTAL orientation
+@property (nonatomic, assign) enum CSLinearLayoutItemVisibility hiddenType;                 // Apply when the layout view is set YES hidden
 @property (nonatomic, assign) CSLinearLayoutItemPadding padding;
 @property (nonatomic, weak) NSDictionary *userInfo;
 @property (nonatomic, assign) NSInteger tag;

--- a/CSLinearLayoutView/CSLinearLayoutView.h
+++ b/CSLinearLayoutView/CSLinearLayoutView.h
@@ -88,12 +88,12 @@ typedef struct {
 
 @interface CSLinearLayoutItem : NSObject
 
-@property (nonatomic, retain) UIView *view;
+@property (nonatomic, strong) UIView *view;
 @property (nonatomic, assign) CSLinearLayoutItemFillMode fillMode;
 @property (nonatomic, assign) CSLinearLayoutItemHorizontalAlignment horizontalAlignment;    // Use horizontalAlignment when the layout view is set to VERTICAL orientation
 @property (nonatomic, assign) CSLinearLayoutItemVerticalAlignment verticalAlignment;        // Use verticalAlignment when the layout view is set to HORIZONTAL orientation
 @property (nonatomic, assign) CSLinearLayoutItemPadding padding;
-@property (nonatomic, assign) NSDictionary *userInfo;
+@property (nonatomic, weak) NSDictionary *userInfo;
 @property (nonatomic, assign) NSInteger tag;
 
 - (id)initWithView:(UIView *)aView;

--- a/CSLinearLayoutView/CSLinearLayoutView.h
+++ b/CSLinearLayoutView/CSLinearLayoutView.h
@@ -58,6 +58,7 @@ typedef enum {
 
 - (void)swapItem:(CSLinearLayoutItem *)firstItem withItem:(CSLinearLayoutItem *)secondItem;
 
+- (CSLinearLayoutItem*)findItemByTag:(NSInteger)tag;
 @end
 
 

--- a/CSLinearLayoutView/CSLinearLayoutView.m
+++ b/CSLinearLayoutView/CSLinearLayoutView.m
@@ -323,6 +323,16 @@
     [self setNeedsLayout];
 }
 
+- (CSLinearLayoutItem*)findItemByTag:(NSInteger)tag
+{
+    for (CSLinearLayoutItem *item in _items) {
+        if (item.tag == tag) {
+            return item;
+        }
+    }
+    return nil;
+}
+
 @end
 
 #pragma mark -

--- a/CSLinearLayoutView/CSLinearLayoutView.m
+++ b/CSLinearLayoutView/CSLinearLayoutView.m
@@ -59,10 +59,8 @@
 
 
 #pragma mark - Lifecycle
-
 - (void)dealloc {
-    [_items release], _items = nil;
-    [super dealloc];
+    items = nil;
 }
 
 
@@ -210,12 +208,10 @@
         return;
     }
     
-    [linearLayoutItem retain];
     
     [_items removeObject:linearLayoutItem];
     [linearLayoutItem.view removeFromSuperview];
     
-    [linearLayoutItem release];
 }
 
 - (void)removeAllItems {
@@ -264,12 +260,10 @@
         return;
     }
     
-    [movingItem retain];
     [_items removeObject:movingItem];
     
     NSUInteger existingItemIndex = [_items indexOfObject:existingItem];
     [_items insertObject:movingItem atIndex:existingItemIndex];
-    [movingItem release];
     
     [self setNeedsLayout];
 }
@@ -279,7 +273,6 @@
         return;
     }
     
-    [movingItem retain];
     [_items removeObject:movingItem];
     
     if (existingItem == [_items lastObject]) {
@@ -288,7 +281,6 @@
         NSUInteger existingItemIndex = [_items indexOfObject:existingItem];
         [_items insertObject:movingItem atIndex:++existingItemIndex];
     }
-    [movingItem release];
     
     [self setNeedsLayout];
 }
@@ -298,7 +290,6 @@
         return;
     }
     
-    [movingItem retain];
     [_items removeObject:movingItem];
     
     if (index == ([_items count] - 1)) {
@@ -306,7 +297,6 @@
     } else {
         [_items insertObject:movingItem atIndex:index];
     }
-    [movingItem release];
     
     [self setNeedsLayout];
 }
@@ -372,17 +362,15 @@
 }
 
 + (CSLinearLayoutItem *)layoutItemForView:(UIView *)aView {
-    CSLinearLayoutItem *item = [[[CSLinearLayoutItem alloc] initWithView:aView] autorelease];
+    CSLinearLayoutItem *item = [[CSLinearLayoutItem alloc] initWithView:aView];
     return item;
 }
 
 #pragma mark - Memory Management
 
 - (void)dealloc {
-    self.view = nil;
     self.userInfo = nil;
     
-    [super dealloc];
 }
 
 

--- a/CSLinearLayoutView/CSLinearLayoutView.m
+++ b/CSLinearLayoutView/CSLinearLayoutView.m
@@ -363,6 +363,7 @@
     self = [super init];
     if (self) {
         self.view = aView;
+        self.tag = aView.tag;
         self.horizontalAlignment = CSLinearLayoutItemHorizontalAlignmentLeft;
         self.verticalAlignment = CSLinearLayoutItemVerticalAlignmentTop;
         self.fillMode = CSLinearLayoutItemFillModeNormal;

--- a/CSLinearLayoutView/CSLinearLayoutView.m
+++ b/CSLinearLayoutView/CSLinearLayoutView.m
@@ -74,6 +74,10 @@
     
     for (CSLinearLayoutItem *item in _items) {
         
+        if (item.view.hidden && item.hiddenType == CSLinearLayoutItemGone) {
+            continue;
+        }
+        
         CGFloat startPadding = 0.0;
         CGFloat endPadding = 0.0;
         
@@ -165,6 +169,10 @@
     CGFloat currentOffset = 0.0;
     
     for (CSLinearLayoutItem *item in _items) {
+        if (item.view.hidden && item.hiddenType == CSLinearLayoutItemGone) {
+            continue;
+        }
+        
         if (_orientation == CSLinearLayoutViewOrientationHorizontal) {
             currentOffset += item.padding.left + item.view.frame.size.width + item.padding.right;
         } else {

--- a/CSLinearLayoutView/CSLinearLayoutView.m
+++ b/CSLinearLayoutView/CSLinearLayoutView.m
@@ -10,6 +10,8 @@
 
 @interface CSLinearLayoutView()
 
+@property (nonatomic, readwrite) NSMutableArray *items;
+
 - (void)setup;
 - (void)adjustFrameSize;
 - (void)adjustContentSize;
@@ -22,7 +24,6 @@
 @synthesize orientation = _orientation;
 @synthesize autoAdjustFrameSize = _autoAdjustFrameSize;
 @synthesize autoAdjustContentSize = _autoAdjustContentSize;
-
 #pragma mark - Factories
 
 - (id)init {
@@ -60,7 +61,7 @@
 
 #pragma mark - Lifecycle
 - (void)dealloc {
-    items = nil;
+    self.items = nil;
 }
 
 


### PR DESCRIPTION
I like CSLinearLayoutView very much. It is difficult to arrange the views in iOS without it.

I have two ideas to make life easier.
1. add findByTag for and let the CSLinearLayoutItem share same tag value with its view.
   https://github.com/stonyw/CSLinearLayoutView/commit/a177cb4aca3fe4362bae78c872c0cb561c10248c
   https://github.com/stonyw/CSLinearLayoutView/commit/41656a5f1671885527c2dbc6aa62219200002f29
   I saw CSLinearLayoutItem did have tag and didn't use it yet. I added findByTag first. I find it is hard to maintain two tag id lists if I use tag. It is better to share the same tag id list.
2. add hidden support.
   https://github.com/stonyw/CSLinearLayoutView/commit/09d8b9c3def4e9f98156e6760f5d8a7367eaee20
   Hidden has two meanings in Android: Invisible and Gone. I want to hide some views in CSLinearLayout and show them again later. "Gone" is useful to me. 
3. The rest commits are for ARC. @jaydee3 has a pending pull request https://github.com/scalessec/CSLinearLayoutView/pull/2 .
