### PR TITLE
add capacity to auto space items

### DIFF
--- a/CSLinearLayoutView/CSLinearLayoutView.h
+++ b/CSLinearLayoutView/CSLinearLayoutView.h
@@ -43,6 +43,7 @@ typedef enum {
 @property (nonatomic, readonly) CGFloat layoutOffset;       // Iterates through the existing layout items and returns the current offset.
 @property (nonatomic, assign) BOOL autoAdjustFrameSize;     // Updates the frame size as items are added/removed. Default is NO.
 @property (nonatomic, assign) BOOL autoAdjustContentSize;   // Updates the contentView as items are added/removed. Default is YES.
+@property (nonatomic, assign) BOOL equallySpaceItems;       // Equally space items along the orientation of the layout. Default is NO.
 
 - (void)addItem:(CSLinearLayoutItem *)linearLayoutItem;
 - (void)removeItem:(CSLinearLayoutItem *)linearLayoutItem;

--- a/CSLinearLayoutView/CSLinearLayoutView.m
+++ b/CSLinearLayoutView/CSLinearLayoutView.m
@@ -47,6 +47,7 @@
     _orientation = CSLinearLayoutViewOrientationVertical;
     _autoAdjustFrameSize = NO;
     _autoAdjustContentSize = YES;
+    _equallySpaceItems = NO;
     self.autoresizesSubviews = NO;
 }
 
@@ -57,6 +58,26 @@
     
     CGFloat relativePosition = 0.0;
     CGFloat absolutePosition = 0.0;
+    
+    CGFloat equalSpace = 0.0;
+    if( _equallySpaceItems ) {
+        CGFloat totalSize = 0.0;
+        for (CSLinearLayoutItem *item in _items) {
+            if( self.orientation == CSLinearLayoutViewOrientationHorizontal )
+                totalSize += item.view.frame.size.width;
+            else
+                totalSize += item.view.frame.size.height;
+        }
+        
+        if( self.orientation == CSLinearLayoutViewOrientationHorizontal && totalSize < self.bounds.size.width )
+        {
+            equalSpace = (self.bounds.size.width - totalSize) / (_items.count + 1);
+        }
+        else if( self.orientation == CSLinearLayoutViewOrientationVertical && totalSize < self.bounds.size.height )
+        {
+            equalSpace = (self.bounds.size.height - totalSize) / (_items.count + 1);
+        }
+    }
     
     for (CSLinearLayoutItem *item in _items) {
         
@@ -91,7 +112,10 @@
             
         }
         
-        relativePosition += startPadding;
+        if( _equallySpaceItems && equalSpace > 0.0 )
+            relativePosition += equalSpace;
+        else
+            relativePosition += startPadding;
         
         CGFloat currentOffset = 0.0;
         if (self.orientation == CSLinearLayoutViewOrientationHorizontal) {
@@ -116,7 +140,9 @@
             
         }
         
-        relativePosition += currentOffset + endPadding;
+        relativePosition += currentOffset;
+        if( !_equallySpaceItems || equalSpace <= 0.0 )
+            relativePosition += endPadding;
         
     }
     


### PR DESCRIPTION
Hi, here is another pull request ^^

Your view is great and helped me a lot. But I missed a feature for my project: it is to auto space items along the orientation if the total size is less than the associated layout size.

So my commit does this. It computes the space to put between each items and just use it instead of the startPadding, and the endPadding is discarded.

It could be completed to handle the paddings specified for each items, so that we do not auto space if the space used is less than the greatest padding of one of the item. It would prevent a wrong compression as the space get thinner if we had items.

But as it is, it helps with static layout with multiple views :)
